### PR TITLE
WIP: Replace hand-rolled CLI usage parser with a library

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "indent-string": "^4.0.0",
-    "minimalistic-assert": "^1.0.1"
+    "minimalistic-assert": "^1.0.1",
+    "parjs": "0.12.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.15",
     "@types/node": "^13.1.0",
+    "@types/parsimmon": "^1.10.0",
     "@typescript-eslint/eslint-plugin": "^2.9.0",
     "@typescript-eslint/parser": "^2.9.0",
     "eslint": "^6.0.1",
@@ -59,6 +60,6 @@
     "chalk": "^3.0.0",
     "indent-string": "^4.0.0",
     "minimalistic-assert": "^1.0.1",
-    "parjs": "0.12.2"
+    "parsimmon": "^1.13.0"
   }
 }

--- a/src/parser/__tests__/parse-argument.test.ts
+++ b/src/parser/__tests__/parse-argument.test.ts
@@ -45,8 +45,20 @@ describe('parseArgument', () => {
       expect(fail).toThrow(/hyphen/i);
     });
 
+    it('throws if the name ends with a hyphen', () => {
+      const fail = () => parseArgument('<argument->');
+
+      expect(fail).toThrow(/hyphen/i);
+    });
+
     it('throws if the name begins with an underline', () => {
       const fail = () => parseArgument('<_argument>');
+
+      expect(fail).toThrow(/underscore/i);
+    });
+
+    it('throws if the name ends with an underline', () => {
+      const fail = () => parseArgument('<argument_>');
 
       expect(fail).toThrow(/underscore/i);
     });

--- a/src/parser/__tests__/parse-argument.test.ts
+++ b/src/parser/__tests__/parse-argument.test.ts
@@ -39,16 +39,16 @@ describe('parseArgument', () => {
       expect(argument.name).toBe('PascalCase');
     });
 
-    it.skip('throws if the name begins with a hyphen', () => {
+    it('throws if the name begins with a hyphen', () => {
       const fail = () => parseArgument('<-argument>');
 
-      expect(fail).toThrow(SyntaxError);
+      expect(fail).toThrow(/hyphen/i);
     });
 
-    it.skip('throws if the name begins with an underline', () => {
+    it('throws if the name begins with an underline', () => {
       const fail = () => parseArgument('<_argument>');
 
-      expect(fail).toThrow(SyntaxError);
+      expect(fail).toThrow(/underscore/i);
     });
   });
 

--- a/src/parser/__tests__/parse-argument.test.ts
+++ b/src/parser/__tests__/parse-argument.test.ts
@@ -1,0 +1,84 @@
+import { parseArgument } from '../parse-argument';
+
+describe('parseArgument', () => {
+  it('throws if parsing fails', () => {
+    const fail = () => parseArgument('-plsThrow*');
+
+    expect(fail).toThrow(SyntaxError);
+  });
+
+  it('includes the raw input in the parsed output', () => {
+    const input = '<weird-argument>';
+    const argument = parseArgument(input);
+
+    expect(argument.raw).toBe(input);
+  });
+
+  describe('name', () => {
+    it('parses the argument name', () => {
+      const argument = parseArgument('<test>');
+
+      expect(argument.name).toBe('test');
+    });
+
+    it('allows hyphens in argument names', () => {
+      const argument = parseArgument('<random-name>');
+
+      expect(argument.name).toBe('random-name');
+    });
+
+    it('allows underlines in argument names', () => {
+      const argument = parseArgument('<random_name>');
+
+      expect(argument.name).toBe('random_name');
+    });
+
+    it('allows uppercase argument names', () => {
+      const argument = parseArgument('<PascalCase>');
+
+      expect(argument.name).toBe('PascalCase');
+    });
+
+    it.skip('throws if the name begins with a hyphen', () => {
+      const fail = () => parseArgument('<-argument>');
+
+      expect(fail).toThrow(SyntaxError);
+    });
+
+    it.skip('throws if the name begins with an underline', () => {
+      const fail = () => parseArgument('<_argument>');
+
+      expect(fail).toThrow(SyntaxError);
+    });
+  });
+
+  describe('required', () => {
+    it('indicates if the argument is required', () => {
+      const argument = parseArgument('<arg>');
+
+      expect(argument.required).toBe(true);
+    });
+
+    it('indicates if the argument is optional', () => {
+      const argument = parseArgument('[arg]');
+
+      expect(argument.required).toBe(false);
+    });
+  });
+
+  describe('variadic', () => {
+    it.each([
+      ['optional', 'multiple', '[...name]'],
+      ['optional', 'single', '[name]'],
+      ['required', 'multiple', '<...name>'],
+      ['required', 'single', '<name>'],
+    ])(
+      'indicates if the %s argument takes %s values',
+      (_required, unit, input) => {
+        const argument = parseArgument(input);
+
+        expect(argument.variadic).toBe(unit === 'multiple');
+      }
+    );
+  });
+});

--- a/src/parser/__tests__/parse-argument.test.ts
+++ b/src/parser/__tests__/parse-argument.test.ts
@@ -4,7 +4,7 @@ describe('parseArgument', () => {
   it('throws if parsing fails', () => {
     const fail = () => parseArgument('-plsThrow*');
 
-    expect(fail).toThrow(SyntaxError);
+    expect(fail).toThrow(/pars(ing|er)/i);
   });
 
   it('includes the raw input in the parsed output', () => {
@@ -49,6 +49,12 @@ describe('parseArgument', () => {
       const fail = () => parseArgument('<_argument>');
 
       expect(fail).toThrow(/underscore/i);
+    });
+
+    it('does not allow empty names', () => {
+      const fail = () => parseArgument('<>');
+
+      expect(fail).toThrow();
     });
   });
 

--- a/src/parser/parse-argument.ts
+++ b/src/parser/parse-argument.ts
@@ -1,0 +1,58 @@
+import { letter, anyCharOf, string } from 'parjs';
+import { many, between, map, or, qthen } from 'parjs/combinators';
+
+export interface Argument {
+  required: boolean;
+  variadic: boolean;
+  type: 'Argument';
+  name: string;
+  raw: string;
+}
+
+// any-argument-name
+const identifier = many()(letter().pipe(or(anyCharOf('-_')))).pipe(
+  map(letters => ({
+    name: letters.join(''),
+    variadic: false,
+  }))
+);
+
+// ...multiple-arguments
+const variadic = string('...')
+  .pipe(qthen(identifier))
+  .pipe(
+    map(arg => ({
+      ...arg,
+      variadic: true,
+    }))
+  );
+
+const potentiallyVariadic = variadic.pipe(or(identifier));
+
+// <required-argument>
+const requiredArgument = potentiallyVariadic
+  .pipe(between('<', '>'))
+  .pipe(map(arg => ({ ...arg, required: true })));
+
+// [optional-argument]
+const optionalArgument = potentiallyVariadic
+  .pipe(between('[', ']'))
+  .pipe(map(arg => ({ ...arg, required: false })));
+
+const argument = requiredArgument.pipe(or(optionalArgument));
+
+export const parseArgument = (input: string): Argument => {
+  const parsed = argument.parse(input);
+
+  if (!parsed.isOk) {
+    throw new SyntaxError(parsed.toString());
+  }
+
+  return {
+    type: 'Argument',
+    variadic: parsed.value.variadic,
+    name: parsed.value.name,
+    required: parsed.value.required,
+    raw: input,
+  };
+};

--- a/src/parser/parse-argument.ts
+++ b/src/parser/parse-argument.ts
@@ -19,13 +19,16 @@ const parser = P.createLanguage({
         required: false,
       }))
       .chain(arg => {
-        if (/^_/.test(arg.name)) {
+        if (/^_/.test(arg.name))
           return P.fail(`Names can't start with an underscore.`);
-        }
 
-        if (/^-/.test(arg.name)) {
+        if (/_$/.test(arg.name))
+          return P.fail(`Names can't end in an underscore.`);
+
+        if (/^-/.test(arg.name))
           return P.fail(`Names can't start with a hyphen.`);
-        }
+
+        if (/-$/.test(arg.name)) return P.fail(`Names can't end in a hyphen.`);
 
         return P.of(arg);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,6 +437,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/parsimmon@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@types/parsimmon/-/parsimmon-1.10.0.tgz#ffb81cb023ff435a41d4710a29ab23c561dc9fdf"
+  integrity sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -919,13 +924,6 @@ chalk@^3.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-char-info@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/char-info/-/char-info-0.3.2.tgz#d4c4d034245c864d1ab17152cd31746b3bd4f0d0"
-  integrity sha512-6P6KW8crZx+N857wZalB4FreR+PhheSLmAk22c8zbQsFhsDxZP1aTDfmOjrzddgp1IBOl53b0Z8kDQrwh4B//A==
-  dependencies:
-    node-interval-tree "^1.3.3"
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -3024,7 +3022,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3279,13 +3277,6 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
-
-node-interval-tree@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/node-interval-tree/-/node-interval-tree-1.3.3.tgz#15ffb904cde08270214acace8dc7653e89ae32b7"
-  integrity sha512-K9vk96HdTK5fEipJwxSvIIqwTqr4e3HRJeJrNxBSeVMNSC/JWARRaX7etOLOuTmrRMeOI/K5TCJu3aWIwZiNTw==
-  dependencies:
-    shallowequal "^1.0.2"
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -3566,14 +3557,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parjs@0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/parjs/-/parjs-0.12.2.tgz#b8a0ca17f4d97ddf2f4ac5aca1a5032dfee9b28a"
-  integrity sha512-SVhKKos/4V9eB5cwC+hsfjhrRaAXIfSFQIpIuHoOV2SsJtGd2lgcgKhM1ljBAd/aDeW925GxUYZF2PZbYIVPtQ==
-  dependencies:
-    char-info "^0.3.1"
-    lodash "^4.17.13"
-
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -3596,6 +3579,11 @@ parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+
+parsimmon@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/parsimmon/-/parsimmon-1.13.0.tgz#6e4ef3dbd45ed6ea6808be600ac4b9c8a44228cf"
+  integrity sha512-5UIrOCW+gjbILkjKPgTgmq8LKf8TT3Iy7kN2VD7OtQ81facKn8B4gG1X94jWqXYZsxG2KbJhrv/Yq/5H6BQn7A==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -4094,11 +4082,6 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-shallowequal@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,6 +920,13 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+char-info@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/char-info/-/char-info-0.3.2.tgz#d4c4d034245c864d1ab17152cd31746b3bd4f0d0"
+  integrity sha512-6P6KW8crZx+N857wZalB4FreR+PhheSLmAk22c8zbQsFhsDxZP1aTDfmOjrzddgp1IBOl53b0Z8kDQrwh4B//A==
+  dependencies:
+    node-interval-tree "^1.3.3"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -3017,7 +3024,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3272,6 +3279,13 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
+
+node-interval-tree@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/node-interval-tree/-/node-interval-tree-1.3.3.tgz#15ffb904cde08270214acace8dc7653e89ae32b7"
+  integrity sha512-K9vk96HdTK5fEipJwxSvIIqwTqr4e3HRJeJrNxBSeVMNSC/JWARRaX7etOLOuTmrRMeOI/K5TCJu3aWIwZiNTw==
+  dependencies:
+    shallowequal "^1.0.2"
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -3551,6 +3565,14 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parjs@0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/parjs/-/parjs-0.12.2.tgz#b8a0ca17f4d97ddf2f4ac5aca1a5032dfee9b28a"
+  integrity sha512-SVhKKos/4V9eB5cwC+hsfjhrRaAXIfSFQIpIuHoOV2SsJtGd2lgcgKhM1ljBAd/aDeW925GxUYZF2PZbYIVPtQ==
+  dependencies:
+    char-info "^0.3.1"
+    lodash "^4.17.13"
 
 parse-json@^4.0.0:
   version "4.0.0"
@@ -4072,6 +4094,11 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
+
+shallowequal@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Having very few dependencies is nice. Maintaining a hand-rolled parser
is not. I'm migrating away from my hand-written usage parser onto
a parser combinator library called [parsimmon](https://github.com/jneen/parsimmon).